### PR TITLE
Upgrade Lambda runtime to Node.js 20.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ awsx.apigateway
 
 // A Lambda function to invoke.
 const eventHandler = new aws.lambda.CallbackFunction("handler", {
-    runtime: Runtime.NodeJS18dX,
+    runtime: Runtime.NodeJS20dX,
     callback: async (event, context) => {
         return {
             statusCode: 200,


### PR DESCRIPTION
This PR upgrades the AWS Lambda function runtime from Node.js 18.x to Node.js 20.x to use the latest supported runtime version.

## Changes Made
- Updated the Lambda function runtime from `Runtime.NodeJS18dX` to `Runtime.NodeJS20dX` in `index.js`

## Benefits
- Access to the latest Node.js features and performance improvements
- Enhanced security with the latest runtime version
- Better long-term support alignment

## Testing
After this change is deployed, the Lambda function will run on Node.js 20.x runtime. The code should continue to work as expected since it doesn't use any deprecated Node.js features.

## Notes
Node.js 20.x is the current latest runtime supported by AWS Lambda, providing improved performance and security over the previous Node.js 18.x version.