### PR TITLE
Upgrade Lambda Node.js runtime to Node.js 20.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ awsx.apigateway
 
 // A Lambda function to invoke.
 const eventHandler = new aws.lambda.CallbackFunction("handler", {
-    runtime: Runtime.NodeJS18dX,
+    runtime: Runtime.NodeJS20dX,
     callback: async (event, context) => {
         return {
             statusCode: 200,


### PR DESCRIPTION
This PR upgrades the AWS Lambda function runtime from Node.js 18.x to Node.js 20.x to use the latest supported version.

## Changes
- Updated `runtime` property in `index.js` from `Runtime.NodeJS18dX` to `Runtime.NodeJS20dX`

## Benefits
- Uses the latest LTS version of Node.js supported by AWS Lambda
- Improved performance and security features
- Access to latest Node.js language features and APIs

## Testing
After deployment, the Lambda function will run on Node.js 20.x runtime while maintaining the same functionality.